### PR TITLE
set compose version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: "3.3"
 
 services:
   db:
@@ -48,7 +48,7 @@ services:
       - ./.env
     links:
       - redis
-    depends_on: 
+    depends_on:
       - redis
       - db
 


### PR DESCRIPTION
This was a quick way for me to get past this error while running `docker-compose up` on the market watcher lightsail instance
```
ERROR: Version in "./docker-compose.yaml" is unsupported. You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/
```