### PR TITLE
django-secret-key

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,3 +1,6 @@
+# Django
+DJANGO_SECRET_KEY=<django-secret-key>
+
 #HOST
 HOSTNAME=http://localhost:8000
 

--- a/market_watcher/settings.py
+++ b/market_watcher/settings.py
@@ -23,7 +23,7 @@ HOSTNAME = os.environ.get("HOSTNAME")
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-+^2=32b11^xp(b#7nb33cpvp=i9!lrs95fi*^-$lp$muq9sm)n"
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Updated `SECRET_KEY` in `settings.py` and also updated the the .env.default format.
The `SECRET_KEY` used is available on notion.